### PR TITLE
Tighten CodeCov settings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,4 +53,4 @@ jobs:
       with:
         files: coverage.out
         flags: unittests
-        fail_ci_if_error: false
+        fail_ci_if_error: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,14 +3,14 @@ coverage:
     project:
       default:
         target: auto
-        threshold: 75%
+        threshold: 90%
         base: auto
     patch:
       default:
         target: auto
-        threshold: 75%
+        threshold: 90%
         base: auto
 
 codecov:
-  require_ci_to_pass: false
+  require_ci_to_pass: true
   disable_default_path_fixes: true


### PR DESCRIPTION

`fail_ci_if_error: true` means: uploads must succeed for CI to pass.

`require_ci_to_pass: true` means coverage checks only when CI is already green.